### PR TITLE
Tilt status implemented

### DIFF
--- a/ARiF.cpp
+++ b/ARiF.cpp
@@ -156,6 +156,12 @@ static byte ARiFClass::update() {
         client.stop();
         return CMD_SHADETILT;
         break;
+      case CMD_SHADESTOP:
+        client.println(F(HTTP_200_OK));
+        client.println();
+        client.stop();
+        return CMD_SHADESTOP;
+        break;
       case CMD_UNKNOWN:
         client.println(F(HTTP_500_Error));
         client.stop();
@@ -214,6 +220,7 @@ static int ARiFClass::getValue(char *buff, int value) {
     if (strstr(buff, "cmd=shadeTILT")) return CMD_SHADETILT;
     if (strstr(buff, "cmd=shadeUP")) return CMD_SHADEUP;
     if (strstr(buff, "cmd=shadeDOWN")) return CMD_SHADEDOWN;
+    if (strstr(buff, "cmd=shadeSTOP")) return CMD_SHADESTOP;
     return CMD_UNKNOWN;
   }
 }

--- a/ARiF.h
+++ b/ARiF.h
@@ -31,6 +31,7 @@
 #define CMD_SHADETILT 5
 #define CMD_SHADEUP   6
 #define CMD_SHADEDOWN 7
+#define CMD_SHADESTOP 8
 #define CMD_UNKNOWN   10
 
 /* values returned by update() other than the CMDs above */

--- a/Shade.cpp
+++ b/Shade.cpp
@@ -39,6 +39,7 @@ void Shade::init(byte shadeID) {
   movementRange = DEFAULT_RANGE;
   synced = false;
   justStoppedVar = false;
+  justStoppedTiltVar = false;
 
   /* filling in the section borders with the border seconds of the movement range */
   sections[0] = 0;
@@ -135,7 +136,7 @@ byte Shade::update() {
   if (timeCheck(&tiltRun)) {
     Serial.println("Stopping tilt movement");
     tiltMovement = false;
-    this->stop();
+    this->tiltStop();
   }
   
   if (timeCheck(&updateExec)) { 
@@ -288,6 +289,16 @@ void Shade::stop() {
   desiredPosition = position;
 }
 
+void Shade::tiltStop() {
+  digitalWrite(outPinUp, Shade::low);
+  digitalWrite(outPinDown, Shade::low);
+  outPinUpState = Shade::low;
+  outPinDownState = Shade::low;
+  justStoppedTiltVar = true;
+  tiltMovement = false;
+  desiredPosition = position;
+}
+
 bool Shade::isMoving() {
   if (outPinDownState == Shade::high || outPinUpState == Shade::high) {
     return true;
@@ -315,6 +326,15 @@ bool Shade::isMovingDown() {
 bool Shade::justStopped() {
   if (justStoppedVar) {
     justStoppedVar = false;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool Shade::justStoppedTilt() {
+  if (justStoppedTiltVar) {
+    justStoppedTiltVar = false;
     return true;
   } else {
     return false;

--- a/Shade.h
+++ b/Shade.h
@@ -78,6 +78,7 @@ class Shade {
     bool justStoppedVar;
     bool justStartedUpVar;
     bool justStartedDownVar;
+    bool justStoppedTiltVar;
 
     byte oldSec;
 
@@ -163,6 +164,9 @@ class Shade {
   /* stops the shade */
   void stop();
 
+  /* stops the shade after tilt movement */
+  void tiltStop();
+
   /* returns true if the shade is currently moving in either direction */
   bool isMoving();
   bool isMovingUp();
@@ -172,6 +176,7 @@ class Shade {
   bool justStopped();
   bool justStartedUp();
   bool justStartedDown();
+  bool justStoppedTilt();
 
   /* sets the desired position of the shade to a given value */
   void toPosition(byte position);

--- a/iot-hub-c.ino
+++ b/iot-hub-c.ino
@@ -166,7 +166,7 @@ for (int i = 0; i < SHADES; i++) {
   //byte pos = shades[i].update();
   if (shades[i].update() <= 100) {
     Serial.println("Sending 1 shade position");
-    ARiF.sendShadePosition(shadeIDs[i], shades[i].getCurrentPosition());
+    //ARiF.sendShadePosition(shadeIDs[i], shades[i].getCurrentPosition());
   }
     
   if (shades[i].isUpPressed()) {
@@ -186,9 +186,14 @@ for (int i = 0; i < SHADES; i++) {
     }
     measure = true;
   }
+
+  if (shades[i].justStoppedTilt()) {
+    ARiF.sendShadeTilt(shadeIDs[i], shades[i].getTilt());
+  }
   
   if (shades[i].justStopped()) {
     ARiF.sendShadeStop(shadeIDs[i]);
+    ARiF.sendShadePosition(shadeIDs[i], shades[i].getCurrentPosition());
   }
   if (shades[i].justStartedDown()) {
     ARiF.sendShadeDown(shadeIDs[i]);
@@ -253,6 +258,14 @@ switch (ret) {
       if (shades[i].getDevID() == lastDevID) shades[i].setTilt(ARiF.getLastShadeTilt());
     }
     break;
+  case CMD_SHADESTOP:
+    Serial.print("ShadeSTOP received: ");
+    lastDevID = ARiF.getLastDevID();
+    //Serial.println(s.getDevID()); // why s.toPosition() doesn't work??
+    for (int i = 0; i < SHADES; i++) {
+      if (shades[i].getDevID() == lastDevID) shades[i].stop();
+    }
+    break;  
   case CMD_LIGHTON:
     Serial.print("Received lightON command from: ");
     Serial.print(ARiF.getLastDevID());


### PR DESCRIPTION
The following changes were made: 1. Each shade is now sending the tilt status after tilt has been modified. Wether moving or not. 2. Shade will now report position status only once it stops its movement. There is no reporting of interim positions. 3. shadeSTOP command has been added. Now it is possible to stop the shade while it is moving.

;